### PR TITLE
Correct attribute name for dtbo image partition size

### DIFF
--- a/aospdtgen/templates/BoardConfig.mk.jinja2
+++ b/aospdtgen/templates/BoardConfig.mk.jinja2
@@ -129,7 +129,7 @@ BOARD_FLASH_BLOCK_SIZE := {{ boot_configuration.pagesize|int * 64 }} # (BOARD_KE
 {% endif %}
 BOARD_BOOTIMAGE_PARTITION_SIZE := {{ boot_configuration.boot_image_info.origsize }}
 {% if boot_configuration.dtbo %}
-BOARD_DTBOIMAGE_PARTITION_SIZE := {{ boot_configuration.dtbo.stat().st_size }}
+BOARD_DTBOIMG_PARTITION_SIZE := {{ boot_configuration.dtbo.stat().st_size }}
 {% endif %}
 {% if boot_configuration.recovery_image_info %}
 BOARD_RECOVERYIMAGE_PARTITION_SIZE := {{ boot_configuration.recovery_image_info.origsize }}


### PR DESCRIPTION
Using `BOARD_DTBOIMAGE_PARTITION_SIZE` to build my device always failed with `avbtool add_hash_footer: error: argument --partition_size: expected one argument`.
I found that the dtbo image partition size is defined as `BOARD_DTBOIMG_PARTITION_SIZE` in `build/core/Makefile`, but what confuses me is some old device still using `BOARD_DTBOIMAGE_PARTITION_SIZE`...Should we correct it?